### PR TITLE
Make animate function public

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,30 @@ Inputs:
 Outputs:
 - `complete`: emits when the animation completes
 
+#### Re-animate at will
+
+To re-animate the countUp when you want (maybe when some custom events take place or in setInterval for example), select the countUp and call the `animate()` function on it.
+
+Add a template ref variable to the markup (with #)
+
+```html
+<h1 #countUp [countUp]="myEndVal" [options]="myOpts">0</h1>
+```
+
+Then, select it with `@ViewChild` in your component's Typescript file (using the template ref # you created). 
+
+```ts
+  @ViewChild('countUp') countUp: CountUpDirective;
+```
+
+Finally, call the animate function where need be.
+
+```ts
+  this.countUp.animate();
+```
+
+Remember to do this inside `ngAfterViewInit()` if you are using something like setInterval on component load.
+
 ## Angular Universal
 
 Yes, this component works with SSR and prerendering!

--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -61,7 +61,7 @@ export class CountUpDirective implements OnChanges {
     }
   }
 
-  private animate() {
+  animate() {
     this.zone.runOutsideAngular(() => {
       this.countUp.reset();
       this.countUp.start(() => {


### PR DESCRIPTION
Before now, the developer can't reanimate the countUp when they want to. For example, the developer may want to be reanimating after every interval of some seconds. Or the developer may want to reanimate the countUp whenever the countUp is scrolled into view (especially when it is not among the first things the user sees on the page).

This pull request makes the [private animate()](https://github.com/inorganik/ngx-countUp/blob/9472c6302aa005382008477609558f17a54c1cfc/projects/count-up/src/lib/count-up.directive.ts#L64) method on the CountUpDirective public and solves the problem. It also adds details about this in the README.

Fix #72 