### PR TITLE
Disable reanimate options change

### DIFF
--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -55,9 +55,21 @@ export class CountUpDirective implements OnChanges {
       } else {
         this.initAndRun();
       }
-    }
-    else if (options?.currentValue !== undefined) {
-      this.initAndRun();
+    } else if (options?.currentValue !== undefined) {
+      if (!options.currentValue.disableReanimateOnOptionsChange) {
+        this.initAndRun();
+      } else {
+        // Update the existing CountUp instance with the new options, but don't re-render
+        if (this.countUp !== undefined) {
+          this.zone.runOutsideAngular(() => {
+            this.countUp.options = {
+              ...this.countUp.options,
+              ...options.currentValue,
+            };
+          });
+        }
+        this.options = options.currentValue;
+      }
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,7 +34,6 @@ export class AppComponent {
       decimalPlaces: 2,
       separator: ':',
       duration: 5,
-      disableReanimateOnOptionsChange: true
     };
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,6 +34,7 @@ export class AppComponent {
       decimalPlaces: 2,
       separator: ':',
       duration: 5,
+      disableReanimateOnOptionsChange: true
     };
   }
 


### PR DESCRIPTION
## I'm submitting a new:
 ```
 [ ] Bug Fix
 [ x ] Feature
 [ ] Other (Refactoring, Added tests, Documentation, ...)
 ```

## Description
Adds support for a new option `disableReanimateOnOptionsChange` to prevent a component controlled by countUp from reanimating when options are changed.

When this option is set to `true`, the component will only reanimate when `endVal` is changed, or explicitly triggered by other means.

 ## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
 ```

 ## How to test:
1. Add the new optional property to `countUp.d.ts`
2. Under `useOptions()` in `app.component.ts`, add the additional option `disableReanimateOnOptionsChange: true`
3. Run the app, observe that changing the options does not trigger a reanimation, but the new options are still reflected when the endVal is changed and the reanimation is triggered.

