### PR TITLE
Add support for setting endVal and Options simultaneously

### DIFF
--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -48,13 +48,18 @@ export class CountUpDirective implements OnChanges {
   
     const { options, endVal } = changes;
   
-    if (endVal?.currentValue !== undefined || options?.currentValue !== undefined) {
-      if (this.countUp !== undefined) {
-        this.zone.runOutsideAngular(() => {
+    if (this.countUp !== undefined) {
+      this.zone.runOutsideAngular(() => {
+        if (endVal?.currentValue !== undefined) {
+          this.countUp.update(this.endVal);
+        }
+        if (options?.currentValue !== undefined) {
           this.countUp.reset();
           this.countUp = undefined;
-        });
-      }
+          this.initAndRun();
+        }
+      });
+    } else {
       this.initAndRun();
     }
   }

--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -39,7 +39,7 @@ export class CountUpDirective implements OnChanges {
     private zone: NgZone,
     @Inject(PLATFORM_ID) private platformId: Object,
   ) {}
-
+  
   ngOnChanges(changes: SimpleChanges): void {
     // don't animate server-side (universal)
     if (!isPlatformBrowser(this.platformId)) {
@@ -48,20 +48,25 @@ export class CountUpDirective implements OnChanges {
   
     const { options, endVal } = changes;
   
-    if (this.countUp !== undefined) {
-      this.zone.runOutsideAngular(() => {
-        if (endVal?.currentValue !== undefined) {
-          this.countUp.update(this.endVal);
-        }
+    if (this.countUp) {
+      if (options?.currentValue !== undefined || endVal?.currentValue !== undefined) {
+        // If options have changed, reinitialize
         if (options?.currentValue !== undefined) {
           this.initAndRun();
+        } else {
+          // Only endVal has changed, update with current options
+          if (!this.options.startVal) {
+            this.options.startVal = this.countUp.frameVal;
+          }
+          this.zone.runOutsideAngular(() => {
+            this.countUp.update(this.endVal);
+          });
         }
-      });
+      }
     } else {
       this.initAndRun();
     }
   }
-
   animate(): void {
     this.zone.runOutsideAngular(() => {
       this.countUp.reset();

--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -54,8 +54,6 @@ export class CountUpDirective implements OnChanges {
           this.countUp.update(this.endVal);
         }
         if (options?.currentValue !== undefined) {
-          this.countUp.reset();
-          this.countUp = undefined;
           this.initAndRun();
         }
       });

--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -45,18 +45,16 @@ export class CountUpDirective implements OnChanges {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
-
+  
     const { options, endVal } = changes;
-    if (endVal?.currentValue !== undefined) {
+  
+    if (endVal?.currentValue !== undefined || options?.currentValue !== undefined) {
       if (this.countUp !== undefined) {
         this.zone.runOutsideAngular(() => {
-          this.countUp.update(this.endVal);
+          this.countUp.reset();
+          this.countUp = undefined;
         });
-      } else {
-        this.initAndRun();
       }
-    }
-    else if (options?.currentValue !== undefined) {
       this.initAndRun();
     }
   }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,6 +8,7 @@
 <input type="text" [(ngModel)]="pickANumber" style="display:block">
 <button (click)="applyEndVal()">Apply</button>
 <button (click)="useOptions()">Test options change</button>
+<button (click)="useOptionsAndEndVal()">Test simultaneous options and endval change</button>
 <button (click)="resetOptions()">Reset options</button>
 <div class="vertical-spacer"></div>
 <app-debug-change-detection></app-debug-change-detection>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,6 +37,16 @@ export class AppComponent {
     };
   }
 
+  useOptionsAndEndVal() {
+    this.opts = {
+      decimalPlaces: 1,
+      separator: ',',
+      duration: 3,
+      suffix: " Set options and endVal simultaneously!"
+    };
+    this.endVal = 10000
+  }
+
   resetOptions() {
     this.opts = {
       enableScrollSpy: true,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -42,7 +42,8 @@ export class AppComponent {
       decimalPlaces: 1,
       separator: ',',
       duration: 3,
-      suffix: " Set options and endVal simultaneously!"
+      suffix: " Set options and endVal simultaneously!",
+      startVal: this.endVal
     };
     this.endVal = 10000
   }


### PR DESCRIPTION
Fixes issue #100 

#### How to test
Click the newly created "Test simultaneous options and endval change" button and see that options and endVal are updated simultaneously.

Alternatively, update the existing`useOptions()` function to include an update to`endVal` and see that both updates are made as expected.

#### Known Limitations
In order to preserve the "count between" behavior (e.g. a change from 50 to 100 would start the count at 50 rather than resetting to 0) when updating `endVal` and `options` simultaneously, a `startVal` must be provided in the options, otherwise the counting starts from 0 regardless of the value at the time options are updated. This is consistent with the current behavior of updating just options in isolation.